### PR TITLE
[FEAT] : ⚙ 사용자 프로필 이미지 불러오는 속도 개선

### DIFF
--- a/IDo.xcodeproj/project.pbxproj
+++ b/IDo.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		18C26A022AD941AF00899A6F /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 18C26A012AD941AF00899A6F /* FirebaseAuth */; };
 		18C26A042AD941AF00899A6F /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = 18C26A032AD941AF00899A6F /* FirebaseDatabase */; };
 		18C26A062AD941AF00899A6F /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 18C26A052AD941AF00899A6F /* FirebaseStorage */; };
+		18C6BC7A2AE78DC7000E4D3F /* UserImageSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C6BC792AE78DC7000E4D3F /* UserImageSize.swift */; };
+		18C6BC7C2AE7C564000E4D3F /* URLCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C6BC7B2AE7C564000E4D3F /* URLCache.swift */; };
 		18CCC1752ADD00D7000D092C /* EmptyCountTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CCC16C2ADD00D7000D092C /* EmptyCountTableViewCell.swift */; };
 		18CCC1762ADD00D7000D092C /* CommentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CCC16D2ADD00D7000D092C /* CommentTableViewCell.swift */; };
 		18CCC1772ADD00D7000D092C /* HorizentalImageTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CCC16F2ADD00D7000D092C /* HorizentalImageTitleView.swift */; };
@@ -140,6 +142,8 @@
 		18C055212ADE6EF9003D26E4 /* CommentUpdateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentUpdateViewController.swift; sourceTree = "<group>"; };
 		18C055242ADE8AA3003D26E4 /* ViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewState.swift; sourceTree = "<group>"; };
 		18C269FC2AD9411D00899A6F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		18C6BC792AE78DC7000E4D3F /* UserImageSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserImageSize.swift; sourceTree = "<group>"; };
+		18C6BC7B2AE7C564000E4D3F /* URLCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCache.swift; sourceTree = "<group>"; };
 		18CCC16C2ADD00D7000D092C /* EmptyCountTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyCountTableViewCell.swift; sourceTree = "<group>"; };
 		18CCC16D2ADD00D7000D092C /* CommentTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentTableViewCell.swift; sourceTree = "<group>"; };
 		18CCC16F2ADD00D7000D092C /* HorizentalImageTitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HorizentalImageTitleView.swift; sourceTree = "<group>"; };
@@ -354,6 +358,7 @@
 				10CBA0432AD646CE00F1DA37 /* Margin.swift */,
 				18CCC1802ADD03C4000D092C /* Reusable.swift */,
 				18B12CB92ADFDD1700FB325F /* Identifier.swift */,
+				18C6BC7B2AE7C564000E4D3F /* URLCache.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -382,6 +387,7 @@
 			isa = PBXGroup;
 			children = (
 				18C055242ADE8AA3003D26E4 /* ViewState.swift */,
+				18C6BC792AE78DC7000E4D3F /* UserImageSize.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -635,6 +641,7 @@
 				7FBE185F2AD796AF0052E950 /* BasicCell.swift in Sources */,
 				7FE072A42ADF82E900966916 /* ImageCache.swift in Sources */,
 				18CE9C272AD8ECAB00C921D5 /* Club.swift in Sources */,
+				18C6BC7A2AE78DC7000E4D3F /* UserImageSize.swift in Sources */,
 				7B6D8C632ADFD6CA00FF2194 /* MyProfileViewCell.swift in Sources */,
 				E79223C62AE656AA00867FAF /* APIKey.swift in Sources */,
 				18CCC1782ADD00D7000D092C /* CommentStackView.swift in Sources */,
@@ -651,6 +658,7 @@
 				10CBA0442AD646CE00F1DA37 /* Margin.swift in Sources */,
 				7FE072A82ADFE21200966916 /* TemporaryManager.swift in Sources */,
 				18CE9C2B2AD8ED5E00C921D5 /* Comment.swift in Sources */,
+				18C6BC7C2AE7C564000E4D3F /* URLCache.swift in Sources */,
 				18CCC1792ADD00D7000D092C /* EmptyAbleTableVIew.swift in Sources */,
 				18BD1A912AE0C92B004BC2B1 /* FirebaseCommentManager.swift in Sources */,
 				E74C58E92AD65E1200C2DEF5 /* CategoryCell.swift in Sources */,

--- a/IDo/Enum/UserImageSize.swift
+++ b/IDo/Enum/UserImageSize.swift
@@ -1,0 +1,11 @@
+//
+//  UserImageSize.swift
+//  IDo
+//
+//  Created by 김도현 on 2023/10/24.
+//
+
+enum UserImageSize: String {
+    case small
+    case medium
+}

--- a/IDo/Page/NoticeBoardDetailPage/NoticeBoardDetailViewController.swift
+++ b/IDo/Page/NoticeBoardDetailPage/NoticeBoardDetailViewController.swift
@@ -138,7 +138,7 @@ private extension NoticeBoardDetailViewController {
     }
     
     func addCommentSetup() {
-        firebaseCommentManager.getMyProfileImage(uid: currentUser!.uid) { image in
+        firebaseCommentManager.getMyProfileImage(uid: currentUser!.uid, imageSize: .small) { image in
             DispatchQueue.main.async {
                 self.addCommentStackView.profileImageView.imageView.image = image
                 self.myProfileImage = image
@@ -208,9 +208,11 @@ extension NoticeBoardDetailViewController: UITableViewDelegate, UITableViewDataS
         guard let cell = tableView.dequeueReusableCell(withIdentifier: CommentTableViewCell.identifier, for: indexPath) as? CommentTableViewCell,
               let currentUser else { return UITableViewCell() }
         cell.selectionStyle = .none
+        if let defaultImage = UIImage(systemName: "person.fill") {
+            cell.setUserImage(profileImage: defaultImage)
+        }
         let comment = firebaseCommentManager.modelList[indexPath.row]
-        print(comment.writeUser.profileImageURL)
-        firebaseCommentManager.getUserImage(referencePath: comment.writeUser.profileImageURL) { image in
+        firebaseCommentManager.getUserImage(referencePath: comment.writeUser.profileImageURL, imageSize: .small) { image in
             guard let image else { return }
             cell.setUserImage(profileImage: image)
         }

--- a/IDo/SceneDelegate.swift
+++ b/IDo/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: scene)
 
-        try? Auth.auth().signOut()
+//        try? Auth.auth().signOut()
         if Auth.auth().currentUser != nil {
             window.rootViewController = TabBarController()
         } else {

--- a/IDo/Util/URLCache.swift
+++ b/IDo/Util/URLCache.swift
@@ -1,0 +1,40 @@
+//
+//  URLCache.swift
+//  IDo
+//
+//  Created by 김도현 on 2023/10/24.
+//
+
+import Foundation
+
+class FBURLCache {
+    let urlCache: URLCache
+    let urlSesstion: URLSession = URLSession.shared
+    
+    init() {
+        let cacheSizeMemory = 100 * 1024 * 1024
+        let cacheSizeDisk = 100 * 1024 * 1024
+        let cache = URLCache(memoryCapacity: cacheSizeMemory, diskCapacity: cacheSizeDisk, diskPath: "UserProfileImage")
+        URLCache.shared = cache
+        self.urlCache = URLCache.shared
+    }
+    
+    func downloadURL(url: URL, completion: @escaping (Result<Data,Error>) -> Void) {
+        let request = URLRequest(url: url)
+        if let cachedResponse = urlCache.cachedResponse(for: request) {
+            let data = cachedResponse.data
+            completion(.success(data))
+        } else {
+            urlSesstion.dataTask(with: request) { data, response, error in
+                if let error {
+                    completion(.failure(error))
+                }
+                guard let data,
+                    let response else { return }
+                let cachedData = CachedURLResponse(response: response, data: data)
+                URLCache.shared.storeCachedResponse(cachedData, for: request)
+                completion(.success(data))
+            }.resume()
+        }
+    }
+}


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
사용자 프로필 이미지 불러오는 속도 개선
1. 프로필 이미지 사이즈를 원본 값으로 저장하는게 아니라 사이즈를 조정하여 저장하도록 변경
2. URLCache를 사용하여 이미 불러온 적이 있는 경우 네트워크 통신을 하지않도록 구현
## 작업내용 (이미지)
![Simulator Screen Recording - iPhone 14 Pro - 2023-10-24 at 02 01 07](https://github.com/FiveI-s/IDo/assets/71269216/22e8eaf6-72f1-4a4e-91f3-9f4c1076e34e) </br>
적용전</br></br>
![Simulator Screen Recording - iPhone 14 Pro - 2023-10-24 at 02 01 07](https://github.com/FiveI-s/IDo/assets/71269216/57cd515b-ddb1-4ff8-9610-dbd181c1d260) </br>
적용후
