### PR TITLE
[FEAT] : ⚙ 댓글을 달면 모든 댓글을 다시 그리지 않도록 수정 + FBURLCache에서 Data가 아니라 UIImage를 반환하도록 변경

### DIFF
--- a/IDo/Model/FBDatabaseManager.swift
+++ b/IDo/Model/FBDatabaseManager.swift
@@ -40,8 +40,8 @@ class FBDatabaseManager<T: Codable & Identifier> {
                 completion?(false)
                 return
             }
+            self.modelList.insert(data, at: 0)
             completion?(true)
-            self.modelList.append(data)
         }
         
     }
@@ -138,13 +138,13 @@ class FBDatabaseManager<T: Codable & Identifier> {
     }
     
     func deleteData(data: T, completion: @escaping (isDatabaseActionComplete) -> Void = {_ in}) {
-        modelList.removeAll(where: { $0.id == data.id })
         ref.updateChildValues([data.id: nil]) { error, _ in
             if let error {
                 print(error.localizedDescription)
                 completion(false)
                 return
             }
+            self.modelList.removeAll(where: { $0.id == data.id })
             completion(true)
         }
     }

--- a/IDo/Page/NoticeBoardDetailPage/FirebaseCommentManager.swift
+++ b/IDo/Page/NoticeBoardDetailPage/FirebaseCommentManager.swift
@@ -29,6 +29,7 @@ class FirebaseCommentManaer: FBDatabaseManager<Comment> {
                 if nsError.code == 1 { self.viewState = .error(true) }
                 else { self.viewState = .error(false) }
                 self.update()
+                completion(.failure(error))
                 return
             }
             guard let dataSnapshot else {
@@ -39,11 +40,13 @@ class FirebaseCommentManaer: FBDatabaseManager<Comment> {
             guard let value = dataSnapshot.value as? [String: Any] else {
                 self.viewState = .loaded
                 self.modelList = []
+                completion(.success(self.modelList))
                 return
             }
-            let dataList: [Comment] = self.decodingDataSnapshot(value: value).sorted(by: { $0.createDate <= $1.createDate })
+            let dataList: [Comment] = self.decodingDataSnapshot(value: value).sorted(by: { $0.createDate >= $1.createDate })
             self.viewState = .loaded
             self.modelList = dataList
+            completion(.success(dataList))
         }
     }
     
@@ -80,8 +83,8 @@ class FirebaseCommentManaer: FBDatabaseManager<Comment> {
             guard let url else { return }
             self.urlCache.downloadURL(url: url) { result in
                 switch result {
-                case .success(let data):
-                    completion(UIImage(data: data))
+                case .success(let image):
+                    completion(image)
                 case .failure(let error):
                     print(error.localizedDescription)
                 }

--- a/IDo/Util/FBURLCache.swift
+++ b/IDo/Util/FBURLCache.swift
@@ -6,11 +6,13 @@
 //
 
 import Foundation
+import UIKit
 
 class FBURLCache {
     static let shared = FBURLCache()
     private let urlCache: URLCache
     private let urlSesstion: URLSession = URLSession.shared
+    private let imageCache = NSCache<NSString, UIImage>()
     
     private init() {
         let cacheSizeMemory = 100 * 1024 * 1024
@@ -20,11 +22,20 @@ class FBURLCache {
         self.urlCache = URLCache.shared
     }
     
-    func downloadURL(url: URL, completion: @escaping (Result<Data,Error>) -> Void) {
+    func downloadURL(url: URL, completion: @escaping (Result<UIImage,Error>) -> Void) {
         let request = URLRequest(url: url)
+        if let image = imageCache.object(forKey: url.absoluteString as NSString) {
+            completion(.success(image))
+            return
+        }
         if let cachedResponse = urlCache.cachedResponse(for: request) {
             let data = cachedResponse.data
-            completion(.success(data))
+            if let image = UIImage(data: data) {
+                self.saveCache(data: data, stringUrl: url.absoluteString)
+                completion(.success(image))
+            } else {
+                print("image Data를 읽을수 없습니다.")
+            }
         } else {
             urlSesstion.dataTask(with: request) { data, response, error in
                 if let error {
@@ -34,8 +45,21 @@ class FBURLCache {
                     let response else { return }
                 let cachedData = CachedURLResponse(response: response, data: data)
                 URLCache.shared.storeCachedResponse(cachedData, for: request)
-                completion(.success(data))
+                self.saveCache(data: data, stringUrl: url.absoluteString)
+                if let image = UIImage(data: data) {
+                    completion(.success(image))
+                } else {
+                    print("이미지 data를 읽을수 없습니다.")
+                }
             }.resume()
+        }
+    }
+    
+    private func saveCache(data: Data, stringUrl: String) {
+        DispatchQueue.global().async {
+            if let image = UIImage(data: data) {
+                self.imageCache.setObject(image, forKey: stringUrl as NSString)
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
댓글을 달면 모든 댓글을 다시 그리지 않도록 버그 수정
+
FBURLCache에서 Data가 아니라 UIImage를 반환하도록 변경
Data를 이미지로 변환하는데에도 시간이 걸리기 때문에
NSCache를 이용하여 UIImage 형태로 저장해 놓았다가 image를 반환하도록 코드를 수정하였습니다
## 작업내용 (이미지)
![Simulator Screen Recording - iPhone 14 Pro - 2023-10-26 at 11 01 00](https://github.com/FiveI-s/IDo/assets/71269216/9af01fa5-fe2d-4b9a-933d-074e2ab3a06e)</br>
수정 전</br>
![Simulator Screen Recording - iPhone 14 Pro - 2023-10-26 at 10 59 21](https://github.com/FiveI-s/IDo/assets/71269216/195d8d67-ca56-461e-8f93-dc110f2a0b4a)</br>
수정 후
