### PR TITLE
[FEAT] 게시판 디테일 화면에서 더보기 버튼 클릭시 알림창 뜨고 수정버튼 클릭시 수정화면으로 넘어가도록 구현(삭제 기능 미구현)

### DIFF
--- a/IDo/Page/NoticeBoard/NoticeBoardViewController.swift
+++ b/IDo/Page/NoticeBoard/NoticeBoardViewController.swift
@@ -117,7 +117,7 @@ extension NoticeBoardViewController: UITableViewDelegate, UITableViewDataSource 
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let vc = NoticeBoardDetailViewController(noticeBoard: firebaseManager.noticeBoards[indexPath.row])
+        let vc = NoticeBoardDetailViewController(noticeBoard: firebaseManager.noticeBoards[indexPath.row], club: club, firebaseNoticeBoardManager: firebaseManager)
         vc.delegate = self
 //        let createVC = CreateNoticeBoardViewController(club: club, firebaseManager: firebaseManager)
 //        createVC.editingTitleText = firebaseManager.noticeBoards[indexPath.row].title

--- a/IDo/Page/NoticeBoardDetailPage/Cell/CommentTableViewCell.swift
+++ b/IDo/Page/NoticeBoardDetailPage/Cell/CommentTableViewCell.swift
@@ -15,7 +15,7 @@ class CommentTableViewCell: UITableViewCell, Reusable {
         let label = UILabel()
         label.font = .bodyFont(.small, weight: .regular)
         label.text = "텍스트 입니다"
-        label.numberOfLines = 1
+        label.numberOfLines = 0
         return label
     }()
     var moreButtonTapHandler: () -> Void = {}
@@ -64,7 +64,7 @@ private extension CommentTableViewCell {
         contentLabel.snp.makeConstraints { make in
             make.top.equalTo(writeInfoView.snp.bottom).offset(Constant.margin2)
             make.left.right.equalTo(contentView)
-            make.bottom.equalTo(contentView).inset(Constant.margin2)
+            make.bottom.equalTo(contentView.snp.bottom).inset(Constant.margin2)
         }
     }
     func writeStackViewSetup() {

--- a/IDo/Page/NoticeBoardDetailPage/NoticeBoardDetailViewController.swift
+++ b/IDo/Page/NoticeBoardDetailPage/NoticeBoardDetailViewController.swift
@@ -27,11 +27,15 @@ final class NoticeBoardDetailViewController: UIViewController {
     private var currentUser: User?
     private var myProfileImage: UIImage?
     private let noticeBoard: NoticeBoard
+    private let club: Club
+    private let firebaseNoticeBoardManager: FirebaseManager
     weak var delegate: FirebaseManagerDelegate?
     
-    init(noticeBoard: NoticeBoard) {
+    init(noticeBoard: NoticeBoard, club: Club, firebaseNoticeBoardManager: FirebaseManager) {
         self.noticeBoard = noticeBoard
         self.firebaseCommentManager = FirebaseCommentManaer(refPath: ["CommentList",noticeBoard.id], noticeBoard: noticeBoard)
+        self.club = club
+        self.firebaseNoticeBoardManager = firebaseNoticeBoardManager
         super.init(nibName: nil, bundle: nil)
         self.currentUser = Auth.auth().currentUser
     }
@@ -77,6 +81,7 @@ private extension NoticeBoardDetailViewController {
         autoLayoutSetup()
         tableViewSetup()
         addCommentSetup()
+        noticeBoardSetup()
     }
     func addViews() {
         view.addSubview(commentPositionView)
@@ -101,6 +106,22 @@ private extension NoticeBoardDetailViewController {
         }
         
     }
+    
+    func noticeBoardSetup() {
+        noticeBoardDetailView.writerInfoView.moreButtonTapHandler = { [weak self] in
+            guard let self else { return }
+            let updateHandler: (UIAlertAction) -> Void = { _ in
+                let createNoticeVC = CreateNoticeBoardViewController(club: self.club, firebaseManager: self.firebaseNoticeBoardManager)
+                self.navigationController?.pushViewController(createNoticeVC, animated: true)
+            }
+            let deleteHandler: (UIAlertAction) -> Void = { _ in
+                //MARK: 게시판 삭제 로직 구현
+            }
+            
+            AlertManager.showUpdateAlert(on: self, updateHandler: updateHandler, deleteHandler: deleteHandler)
+        }
+    }
+    
     func tableViewSetup() {
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(commentLongPress))
         commentTableView.addGestureRecognizer(longPress)
@@ -254,29 +275,6 @@ extension NoticeBoardDetailViewController: UITableViewDelegate, UITableViewDataS
             }
             
             AlertManager.showUpdateAlert(on: self, updateHandler: updateHandler, deleteHandler: deleteHandler)
-            
-//            let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-//                            
-//            let cancelAction = UIAlertAction(title: "취소", style: .cancel)
-//            let removeAction = UIAlertAction(title: "댓글 삭제", style: .destructive) { _ in
-//                self.firebaseCommentManager.modelList.remove(at: indexPath.row)
-//            }
-//            let updateAction = UIAlertAction(title: "댓글 수정", style: .default) { _ in
-//                let comment = self.firebaseCommentManager.modelList[indexPath.row]
-//                let vc = CommentUpdateViewController(comment: comment)
-//                vc.commentUpdate = { [weak self] comment in
-//                    guard let self else { return }
-//                    self.firebaseCommentManager.updateDatas(data: comment)
-//                }
-//                vc.hidesBottomBarWhenPushed = true
-//                vc.view.backgroundColor = UIColor(color: .backgroundPrimary)
-//                self.navigationController?.pushViewController(vc, animated: true)
-//            }
-            
-//            alert.addAction(cancelAction)
-//            alert.addAction(updateAction)
-//            alert.addAction(removeAction)
-//            present(alert, animated: true)
         }
         guard let dateText = comment.createDate.diffrenceDate else { return cell }
         cell.setDate(dateText: dateText)

--- a/IDo/Page/NoticeBoardDetailPage/NoticeBoardDetailViewController.swift
+++ b/IDo/Page/NoticeBoardDetailPage/NoticeBoardDetailViewController.swift
@@ -235,28 +235,48 @@ extension NoticeBoardDetailViewController: UITableViewDelegate, UITableViewDataS
         cell.moreButtonTapHandler = { [weak self] in
             //TODO: 같이 LongPress할때와 똑같이 작동함 함수로 뺄 필요가 있음
             guard let self else { return }
-            let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-                            
-            let cancelAction = UIAlertAction(title: "취소", style: .cancel)
-            let removeAction = UIAlertAction(title: "댓글 삭제", style: .destructive) { _ in
-                self.firebaseCommentManager.modelList.remove(at: indexPath.row)
-            }
-            let updateAction = UIAlertAction(title: "댓글 수정", style: .default) { _ in
+            
+            let updateHandler: (UIAlertAction) -> Void = { _ in
                 let comment = self.firebaseCommentManager.modelList[indexPath.row]
                 let vc = CommentUpdateViewController(comment: comment)
                 vc.commentUpdate = { [weak self] comment in
                     guard let self else { return }
-                    self.firebaseCommentManager.updateDatas(data: comment)
+                    self.firebaseCommentManager.updateDatas(data: comment) { _ in
+                        self.commentTableView.reloadRows(at: [indexPath], with: .none)
+                    }
                 }
                 vc.hidesBottomBarWhenPushed = true
                 vc.view.backgroundColor = UIColor(color: .backgroundPrimary)
                 self.navigationController?.pushViewController(vc, animated: true)
             }
+            let deleteHandler: (UIAlertAction) -> Void = { _ in
+                self.firebaseCommentManager.modelList.remove(at: indexPath.row)
+            }
             
-            alert.addAction(cancelAction)
-            alert.addAction(updateAction)
-            alert.addAction(removeAction)
-            present(alert, animated: true)
+            AlertManager.showUpdateAlert(on: self, updateHandler: updateHandler, deleteHandler: deleteHandler)
+            
+//            let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+//                            
+//            let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+//            let removeAction = UIAlertAction(title: "댓글 삭제", style: .destructive) { _ in
+//                self.firebaseCommentManager.modelList.remove(at: indexPath.row)
+//            }
+//            let updateAction = UIAlertAction(title: "댓글 수정", style: .default) { _ in
+//                let comment = self.firebaseCommentManager.modelList[indexPath.row]
+//                let vc = CommentUpdateViewController(comment: comment)
+//                vc.commentUpdate = { [weak self] comment in
+//                    guard let self else { return }
+//                    self.firebaseCommentManager.updateDatas(data: comment)
+//                }
+//                vc.hidesBottomBarWhenPushed = true
+//                vc.view.backgroundColor = UIColor(color: .backgroundPrimary)
+//                self.navigationController?.pushViewController(vc, animated: true)
+//            }
+            
+//            alert.addAction(cancelAction)
+//            alert.addAction(updateAction)
+//            alert.addAction(removeAction)
+//            present(alert, animated: true)
         }
         guard let dateText = comment.createDate.diffrenceDate else { return cell }
         cell.setDate(dateText: dateText)

--- a/IDo/Page/NoticeBoardDetailPage/View/NoticeBoardDetailView.swift
+++ b/IDo/Page/NoticeBoardDetailPage/View/NoticeBoardDetailView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class NoticeBoardDetailView: UIStackView {
     
-    private let writerInfoView: WriterStackView = WriterStackView()
+    let writerInfoView: WriterStackView = WriterStackView()
     private let contentTitleLabel: UILabel = {
         let label = UILabel()
         label.font = .bodyFont(.medium, weight: .bold)

--- a/IDo/SceneDelegate.swift
+++ b/IDo/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: scene)
 
-        try? Auth.auth().signOut()
+//        try? Auth.auth().signOut()
         if Auth.auth().currentUser != nil {
             window.rootViewController = TabBarController()
         } else {

--- a/IDo/View/AlertManager.swift
+++ b/IDo/View/AlertManager.swift
@@ -15,5 +15,16 @@ class AlertManager {
         alertController.addAction(okAction)
         viewController.present(alertController, animated: true, completion: nil)
     }
+    
+    static func showUpdateAlert(on viewController: UIViewController, title: String? = nil, message: String? = nil, updateHandler: ((UIAlertAction) -> Void)? = nil, deleteHandler: ((UIAlertAction) -> Void)? = nil, cancelHandelr: ((UIAlertAction) -> Void)? = nil) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let updateAction = UIAlertAction(title: "수정", style: .default, handler: updateHandler)
+        let deleteAction = UIAlertAction(title: "삭제", style: .destructive, handler: deleteHandler)
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: cancelHandelr)
+        alertController.addAction(updateAction)
+        alertController.addAction(deleteAction)
+        alertController.addAction(cancelAction)
+        viewController.present(alertController, animated: true, completion: nil)
+    }
 }
 


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
게시판 디테일 화면에서 더보기 버튼 클릭시 알림창 뜨고 수정버튼 클릭시 수정화면으로 넘어가도록 구현(삭제 기능 미구현)
## 작업내용 (이미지)
![Simulator Screen Recording - iPhone 14 Pro - 2023-10-27 at 20 44 50](https://github.com/FiveI-s/IDo/assets/71269216/8be81d6f-f6f2-4263-be2b-529affb8b37d)
