### PR TITLE
[FEAT] 다크모드 제외, 클럽 이미지 불러오기전에 클럽 클릭시 이미지를 못 불러오는 버그 수정

### DIFF
--- a/IDo/Info.plist
+++ b/IDo/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/IDo/Page/MeetingPage/MeetingManageViewController.swift
+++ b/IDo/Page/MeetingPage/MeetingManageViewController.swift
@@ -23,10 +23,10 @@ class MeetingManageViewController: UIViewController {
     lazy var storageRef = storage.reference()
     private var meetingsData: MeetingsData
     private var club: Club
-    private let clubImage: UIImage
+    private let clubImage: UIImage?
     var updateHandler: ((Club, Data) -> Void)?
     
-    init(club: Club, clubImage: UIImage) {
+    init(club: Club, clubImage: UIImage?) {
         self.club = club
         self.clubImage = clubImage
         self.meetingsData = MeetingsData(category: club.category)
@@ -114,7 +114,22 @@ class MeetingManageViewController: UIViewController {
         configureUI()
         meetingNameField.text = club.title
         meetingDescriptionField.text = club.description
-        profileImageButton.setImage(clubImage, for: .normal)
+        if let clubImage {
+            profileImageButton.setImage(clubImage, for: .normal)
+        } else {
+            if let imagePath = club.imageURL {
+                FBURLCache.shared.downloadURL(storagePath: imagePath) { result in
+                    switch result {
+                    case .success(let image):
+                        DispatchQueue.main.async {
+                            self.profileImageButton.setImage(image, for: .normal)
+                        }
+                    case .failure(let error):
+                        print(error.localizedDescription)
+                    }
+                }
+            }
+        }
         ref = Database.database().reference()
         manageFinishButton.addTarget(self, action: #selector(manageFinishButtonTapped), for: .touchUpInside)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(notification:)), name: UIResponder.keyboardWillShowNotification, object: nil)

--- a/IDo/Page/NoticeBoard/NoticeHomeController.swift
+++ b/IDo/Page/NoticeBoard/NoticeHomeController.swift
@@ -13,7 +13,7 @@ import UIKit
 final class NoticeHomeController: UIViewController {
     var signUpButtonUpdate: ((AuthState) -> Void)?
     private let firebaseClubDatabaseManager: FirebaseClubDatabaseManager
-    private let clubImage: UIImage
+    private let clubImage: UIImage?
     let memberTableView: IntrinsicTableView = {
         let tableview = IntrinsicTableView()
         tableview.rowHeight = 36 + 8 + 8
@@ -69,7 +69,7 @@ final class NoticeHomeController: UIViewController {
         return view
     }()
     
-    init(club: Club, authState: AuthState, firebaseClubDataManager: FirebaseClubDatabaseManager, clubImage: UIImage) {
+    init(club: Club, authState: AuthState, firebaseClubDataManager: FirebaseClubDatabaseManager, clubImage: UIImage?) {
         self.clubImage = clubImage
         self.firebaseClubDatabaseManager = firebaseClubDataManager
         self.authState = authState
@@ -194,7 +194,21 @@ final class NoticeHomeController: UIViewController {
     func loadDataFromFirebase() {
         label.text = firebaseClubDatabaseManager.model?.title
         textLabel.text = firebaseClubDatabaseManager.model?.description
-        imageView.image = clubImage
+        if let clubImage {
+            imageView.image = clubImage
+        } else {
+            guard let imageURL = firebaseClubDatabaseManager.model?.imageURL else { return }
+            FBURLCache.shared.downloadURL(storagePath: imageURL) { result in
+                switch result {
+                case .success(let image):
+                    DispatchQueue.main.async {
+                        self.imageView.image = image
+                    }
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+        }
     }
 
     func update(club: Club, imageData: Data) {

--- a/IDo/Page/NoticeBoard/NoticeMeetingController.swift
+++ b/IDo/Page/NoticeBoard/NoticeMeetingController.swift
@@ -24,7 +24,7 @@ final class NoticeMeetingController: TabmanViewController {
     private let firebaseManager: FirebaseManager
     private var club: Club
     private let firebaseClubDatabaseManager: FirebaseClubDatabaseManager
-    private let clubImage: UIImage
+    private let clubImage: UIImage?
     private let homeVC: NoticeHomeController
     
     private var authState: AuthState {
@@ -33,7 +33,7 @@ final class NoticeMeetingController: TabmanViewController {
         }
     }
 
-    init(club: Club, currentUser: MyUserInfo, clubImage: UIImage) {
+    init(club: Club, currentUser: MyUserInfo, clubImage: UIImage?) {
         self.club = club
         self.firebaseManager = FirebaseManager(club: club)
         self.clubImage = clubImage


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
다크모드 제외, 클럽 이미지 불러오기전에 클럽 클릭시 이미지를 못 불러오는 버그 수정
