### PR TITLE
[FIX] 키보드 엔터키 입력시 키보드가 닫히도록 구현 + 회원가입 비밀번호 입력시 뷰가 올라가는 부분 일단 제외

### DIFF
--- a/IDo/Page/LoginPage/LoginViewController.swift
+++ b/IDo/Page/LoginPage/LoginViewController.swift
@@ -28,9 +28,16 @@ class LoginViewController: UIViewController {
         loginView.signUpRightLabel.addGestureRecognizer(tapGesture)
 
         // Do any additional setup after loading the view.
+        loginView.emailTextField.delegate = self
+        loginView.passwordTextField.delegate = self
         clickLoginButton()
         clickDefaultLoginButton()
 //        clickSignupButton()
+    }
+    
+    // 화면 터치 시 키보드 내려가게 구현
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
     }
 }
 
@@ -43,11 +50,6 @@ private extension LoginViewController {
         let signUpVC = UINavigationController(rootViewController: SignUpViewController())
         signUpVC.modalPresentationStyle = .fullScreen
         present(signUpVC, animated: true)
-    }
-    
-    // 화면 터치 시 키보드 내려가게 구현
-    override internal func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        view.endEditing(true)
     }
     
     func clickDefaultLoginButton() {
@@ -192,5 +194,12 @@ private extension LoginViewController {
                 }
             }
         }
+    }
+}
+
+extension LoginViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        view.endEditing(true)
+        return true
     }
 }

--- a/IDo/Page/SignUpPage/SignUpViewController.swift
+++ b/IDo/Page/SignUpPage/SignUpViewController.swift
@@ -265,6 +265,8 @@ private extension SignUpViewController {
         setupButton()
         setupKeyboardEvent()
         setupHyperLink()
+        emailTextField.delegate = self
+        authenticationNumberTextField.delegate = self
         passwordTextField.delegate = self
         passwordConfirmTextField.delegate = self
     }
@@ -376,7 +378,7 @@ private extension SignUpViewController {
         }
         
         privacyPolicyStackView.snp.makeConstraints { make in
-            make.top.equalTo(termsStackView.snp.bottom).offset(Constant.margin1)
+            make.top.equalTo(termsStackView.snp.bottom).offset(Constant.margin2)
             make.left.equalToSuperview().inset(Constant.margin4)
             make.right.equalToSuperview().inset(Constant.margin4)
         }
@@ -563,14 +565,14 @@ private extension SignUpViewController {
     }
     
     func setupKeyboardEvent() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardWillShow),
-                                               name: UIResponder.keyboardWillShowNotification,
-                                               object: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardWillHide),
-                                               name: UIResponder.keyboardWillHideNotification,
-                                               object: nil)
+//        NotificationCenter.default.addObserver(self,
+//                                               selector: #selector(keyboardWillShow),
+//                                               name: UIResponder.keyboardWillShowNotification,
+//                                               object: nil)
+//        NotificationCenter.default.addObserver(self,
+//                                               selector: #selector(keyboardWillHide),
+//                                               name: UIResponder.keyboardWillHideNotification,
+//                                               object: nil)
     }
     
     @objc func keyboardWillShow(_ sender: Notification) {
@@ -761,6 +763,11 @@ extension SignUpViewController: UITextFieldDelegate {
             validatePasswordConfirm()
         }
     }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        view.endEditing(true)
+        return true
+    }
 
     private func validatePasswordConfirm() {
         let passwordText = passwordTextField.text ?? ""
@@ -782,28 +789,28 @@ extension SignUpViewController: UITextFieldDelegate {
     }
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        if textField == emailTextField {
-            view.frame.origin.y = 0
-               
-        } else if textField == passwordTextField || textField == passwordConfirmTextField || textField == authenticationNumberTextField {
-            // 부드러운 효과를 위해 애니메이션 처리
-            UIView.animate(withDuration: 0.3) {
-                let transform = CGAffineTransform(translationX: 0, y: -100)
-                self.view.transform = transform
-            }
-        }
+//        if textField == emailTextField {
+//            view.frame.origin.y = 0
+//
+//        } else if textField == passwordTextField || textField == passwordConfirmTextField || textField == authenticationNumberTextField {
+//            // 부드러운 효과를 위해 애니메이션 처리
+//            UIView.animate(withDuration: 0.3) {
+//                let transform = CGAffineTransform(translationX: 0, y: -100)
+//                self.view.transform = transform
+//            }
+//        }
     }
        
     func textFieldDidEndEditing(_ textField: UITextField) {
-        if textField == emailTextField {
-            view.frame.origin.y = 0
-               
-        } else if textField == passwordTextField {
-            UIView.animate(withDuration: 0.3) {
-                let transform = CGAffineTransform(translationX: 0, y: 0)
-                self.view.transform = transform
-            }
-        }
+//        if textField == emailTextField {
+//            view.frame.origin.y = 0
+//
+//        } else if textField == passwordTextField {
+//            UIView.animate(withDuration: 0.3) {
+//                let transform = CGAffineTransform(translationX: 0, y: 0)
+//                self.view.transform = transform
+//            }
+//        }
     }
 }
 


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
키보드 엔터키 입력시 키보드가 닫히도록 구현 
회원가입 비밀번호 입력시 뷰가 올라가는 부분 일단 제외(가끔 버튼이 안보이는 버그가 있고 키보드가 올라가도 버튼이 안보이는 경우도 있음)
## 작업내용 (이미지)
