### PR TITLE
[FIX] : 🐛 게시글 상세 더보기 버튼 규격 조정 / 게시글 삭제 시, 바로 목록으로 화면 이동 / 게시글 삭제 시, Storage에서 이미지 삭제 동기화

### DIFF
--- a/IDo/Page/NoticeBoard/NoticeBoardCRUD.swift
+++ b/IDo/Page/NoticeBoard/NoticeBoardCRUD.swift
@@ -178,6 +178,7 @@ class FirebaseManager {
     func deleteNoticeBoard(at index: Int, completion: ((Bool) -> Void)? = nil) {
         if index >= 0, index < self.noticeBoards.count {
             let noticeBoardID = self.noticeBoards[index].id
+            let imagePaths = self.noticeBoards[index].imageList?.map { $0.savedImagePath } ?? []
             let ref = Database.database().reference().child("noticeBoards").child(noticeBoards[index].clubID).child(noticeBoardID)
             
             ref.removeValue { error, _ in
@@ -191,7 +192,11 @@ class FirebaseManager {
                     self.removeMyNoticeBoard(noticeBoard: self.noticeBoards[index])
                     self.noticeBoards.remove(at: index)
                     self.delegate?.reloadData()
-                    completion?(true)
+                    self.deleteImage(noticeBoardID: self.noticeBoards[index].id, imagePaths: imagePaths) { success in
+                        if success {
+                            completion?(true)
+                        }
+                    }
                 }
             }
         }

--- a/IDo/Page/NoticeBoardDetailPage/NoticeBoardDetailViewController.swift
+++ b/IDo/Page/NoticeBoardDetailPage/NoticeBoardDetailViewController.swift
@@ -172,6 +172,7 @@ private extension NoticeBoardDetailViewController {
                         if success {
                             self.firebaseCommentManager.deleteAllCommentList()
                             self.firebaseNoticeBoardManager.readNoticeBoard()
+                            self.navigationController?.popViewController(animated: true)
                         }
                     }
                 }

--- a/IDo/Page/NoticeBoardDetailPage/View/WriterStackView.swift
+++ b/IDo/Page/NoticeBoardDetailPage/View/WriterStackView.swift
@@ -106,6 +106,11 @@ private extension WriterStackView {
         let gesture = UITapGestureRecognizer(target: self, action: #selector(moreButtonTap))
         moreImageView.isUserInteractionEnabled = true
         moreImageView.addGestureRecognizer(gesture)
+        moreImageView.contentMode = .center
+        moreImageView.snp.makeConstraints { make in
+            make.height.equalTo(20)
+            make.width.equalTo(18.5)
+        }
     }
     
     @objc func moreButtonTap() {

--- a/IDo/SceneDelegate.swift
+++ b/IDo/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: scene)
 
-        try? Auth.auth().signOut()
+//        try? Auth.auth().signOut()
         if Auth.auth().currentUser != nil {
             guard let uid = Auth.auth().currentUser?.uid else { return }
             MyProfile.shared.getUserProfile(uid: uid) { isSuccess in


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
지금 게시글 상세 페이지에서 점 3개 버튼 가로 길어지는 부분은 일단 constraint로 값을 줘서 고정을 시켰고(pro랑 se랑 동일한 규격이어서 이렇게 진행을 했습니다.), 게시글을 삭제하고 계속 상세 페이지에 있는 부분은 pop을 해서 바로 목록으로 넘어가게 했습니다!(completion 핸들에서 성공했을 때, 가장 마지막에 넣어서 아마 타이밍은 잘 맞을 것 같습니다) 그리고 게시글을 삭제할 때 Storage에서도 이미지를 삭제하는 함수 추가해서 수정했습니다!!

## 작업내용 (이미지)
