### PR TITLE
[FIX] 프로필 수정 취소시 텍스트 카운트가 변하지 않는 버그, 취소버튼 클릭시 취소버튼이 사라지지 않는 버그 수정

### DIFF
--- a/IDo.xcodeproj/project.pbxproj
+++ b/IDo.xcodeproj/project.pbxproj
@@ -903,7 +903,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.iOS.camp.iDo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.iOS.nbcamp.iDo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -935,7 +935,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.iOS.camp.iDo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.iOS.nbcamp.iDo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/IDo/Page/MyProfilePage/MyProfileViewController.swift
+++ b/IDo/Page/MyProfilePage/MyProfileViewController.swift
@@ -447,11 +447,16 @@ private extension MyProfileViewController {
             print("사용자 정보가 없습니다.")
             return
         }
+        
+        hiddenLeftButton()
+        
         navigationItem.rightBarButtonItem?.image = UIImage(systemName: "square.and.pencil")
         profileName.isUserInteractionEnabled = false
         profileName.text = myProfile.nickName
         selfInfoDetail.isUserInteractionEnabled = false
         selfInfoDetail.text = myProfile.description
+        selfInfoInt.text = "(\(myProfile.description?.count ?? 0)/300)"
+        selfInfoInt.textColor = UIColor(color: .placeholder)
         choiceEnjoyTextField.isUserInteractionEnabled = false
         choiceEnjoyTextField.text = myProfile.hobbyList?.first
 
@@ -482,6 +487,7 @@ private extension MyProfileViewController {
             // 각각 텍스트뷰를 활성화 시킴
             profileName.isUserInteractionEnabled = true
             selfInfoDetail.isUserInteractionEnabled = true
+            selfInfoInt.textColor = UIColor(color: .textStrong)
             choiceEnjoyTextField.isUserInteractionEnabled = true
             writeMe.isHidden = true // "작성한글" title Label 숨기기
             writeMeTableView.isHidden = true // 작성한글 리스트 숨기기
@@ -498,6 +504,7 @@ private extension MyProfileViewController {
             
             profileName.isUserInteractionEnabled = false
             selfInfoDetail.isUserInteractionEnabled = false
+            selfInfoInt.textColor = UIColor(color: .placeholder)
             choiceEnjoyTextField.isUserInteractionEnabled = false
 
             writeMe.isHidden = false // 작성한글 title Label 나타내기

--- a/IDo/SceneDelegate.swift
+++ b/IDo/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: scene)
 
-        try? Auth.auth().signOut()
+//        try? Auth.auth().signOut()
         if Auth.auth().currentUser != nil {
             guard let uid = Auth.auth().currentUser?.uid else { return }
             MyProfile.shared.getUserProfile(uid: uid) { isSuccess in


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
 프로필 수정 취소시 텍스트 카운트가 변하지 않는 버그, 취소버튼 클릭시 취소버튼이 사라지지 않는 버그 수정
## 작업내용 (이미지)
