### PR TITLE
[Fix] 게시판 이미지 셀을 못가져오는 버그 수정

### DIFF
--- a/IDo/Page/NoticeBoard/CreateNoticeBoard/CreateNoticeBoardViewController.swift
+++ b/IDo/Page/NoticeBoard/CreateNoticeBoard/CreateNoticeBoardViewController.swift
@@ -417,13 +417,13 @@ extension CreateNoticeBoardViewController: UICollectionViewDelegate, UICollectio
 extension CreateNoticeBoardViewController {
     func updateAutolayoutCollectionView() {
         DispatchQueue.main.async {
-            if self.firebaseManager.selectedImage.count == 0 {
+            if self.firebaseManager.newSelectedImage.count == 0 {
                 self.createNoticeBoardView.galleryCollectionView.snp.updateConstraints { make in
                     make.height.equalTo(0)
                 }
                 return
             }
-            let rows = ceil(CGFloat(self.firebaseManager.selectedImage.count) / 5.0)
+            let rows = ceil(CGFloat(self.firebaseManager.newSelectedImage.count) / 5.0)
             let spacing = rows * 2
             let cellHeight = (self.createNoticeBoardView.galleryCollectionView.bounds.width - 8) / 5
             let contentHeight = rows * cellHeight + spacing


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
게시판 이미지 셀을 못가져오는 버그 수정
## 작업내용 (이미지)
