### PR TITLE
[FIX] 모임을 생성할때 이미지가 겹쳐서 나오거나 다른 이미지가 나오는 버그 수정 + 모임 삭제시 내 모임 목록이 전부 안보이는 버그 해결

### DIFF
--- a/IDo/Page/CategoryPage/MeetingViewController.swift
+++ b/IDo/Page/CategoryPage/MeetingViewController.swift
@@ -174,23 +174,8 @@ extension MeetingViewController: UITableViewDelegate, UITableViewDataSource {
         if let imageURL = club.imageURL {
             cell.indexPath = indexPath
             FBURLCache.shared.cancelDownloadURL(indexPath: indexPath)
-//            meetingsData.loadImage(storagePath: imageURL, clubId: club.id) { result in
-//                switch result {
-//                case .success(let image):
-//                    DispatchQueue.main.async {
-//                        cell.basicImageView.image = image
-//                    }
-//
-//                case .failure(let error):
-//                    print(error)
-//                }
-//            }
             meetingsData.loadImageResize(storagePath: imageURL, clubId: club.id, imageSize: .small) { [weak self] result in
                 DispatchQueue.main.async {
-//                    guard let self = self,
-//                          let cell = tableView.cellForRow(at: indexPath) as? BasicCell else {
-//                        return
-//                    }
                     switch result {
                     case .success(let image):
                         cell.basicImageView.image = image

--- a/IDo/Page/CategoryPage/MeetingViewController.swift
+++ b/IDo/Page/CategoryPage/MeetingViewController.swift
@@ -32,10 +32,6 @@ class MeetingViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 //        loadDataFromFirebase()
-        meetingsData.update = { [weak self] in
-            self?.tableView.reloadData()
-            self?.updateNoMeetingsViewVisibility()
-        }
         navigationController?.navigationBar.tintColor = UIColor.black
         setupNavigationBar()
         setupTableView()
@@ -52,7 +48,9 @@ class MeetingViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        meetingsData.readClub { _ in
+        meetingsData.readClub { [weak self] _ in
+            guard let self else { return }
+            self.tableView.reloadData()
             self.setupEmptyMessageView()
             self.updateNoMeetingsViewVisibility()
         }
@@ -174,8 +172,8 @@ extension MeetingViewController: UITableViewDelegate, UITableViewDataSource {
         cell.basicImageView.image = nil
         
         if let imageURL = club.imageURL {
-            cell.storagePath = imageURL
-            FBURLCache.shared.cancelDownloadURL(storagePath: imageURL)
+            cell.indexPath = indexPath
+            FBURLCache.shared.cancelDownloadURL(indexPath: indexPath)
 //            meetingsData.loadImage(storagePath: imageURL, clubId: club.id) { result in
 //                switch result {
 //                case .success(let image):
@@ -187,15 +185,18 @@ extension MeetingViewController: UITableViewDelegate, UITableViewDataSource {
 //                    print(error)
 //                }
 //            }
-            meetingsData.loadImageResize(storagePath: imageURL, clubId: club.id, imageSize: .small) { result in
-                switch result {
-                case .success(let image):
-                    DispatchQueue.main.async {
+            meetingsData.loadImageResize(storagePath: imageURL, clubId: club.id, imageSize: .small) { [weak self] result in
+                DispatchQueue.main.async {
+//                    guard let self = self,
+//                          let cell = tableView.cellForRow(at: indexPath) as? BasicCell else {
+//                        return
+//                    }
+                    switch result {
+                    case .success(let image):
                         cell.basicImageView.image = image
+                    case .failure(let error):
+                        print(error)
                     }
-                    
-                case .failure(let error):
-                    print(error)
                 }
             }
         }

--- a/IDo/Page/NoticeBoard/Cell/NoticeBoardTableViewCell.swift
+++ b/IDo/Page/NoticeBoard/Cell/NoticeBoardTableViewCell.swift
@@ -13,7 +13,6 @@ class NoticeBoardTableViewCell: UITableViewCell {
     static let identifier = "NoticeBoardTableViewCell"
     
     var indexPath: IndexPath?
-    var storagePath: String?
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -29,8 +28,8 @@ class NoticeBoardTableViewCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        if let storagePath {
-            FBURLCache.shared.cancelDownloadURL(storagePath: storagePath)
+        if let indexPath {
+            FBURLCache.shared.cancelDownloadURL(indexPath: indexPath)
         }
         profileImageView.image = nil
     }

--- a/IDo/Page/NoticeBoard/NoticeBoardViewController.swift
+++ b/IDo/Page/NoticeBoard/NoticeBoardViewController.swift
@@ -85,8 +85,8 @@ extension NoticeBoardViewController: UITableViewDelegate, UITableViewDataSource 
         cell.contentLabel.text = noticeBoard.content
         cell.timeLabel.text = noticeBoard.createDate.toDate?.diffrenceDate ?? noticeBoard.createDate
         if let profileImageURL = noticeBoard.rootUser.profileImagePath {
-            FBURLCache.shared.cancelDownloadURL(storagePath: profileImageURL)
-            cell.storagePath = profileImageURL
+            FBURLCache.shared.cancelDownloadURL(indexPath: indexPath)
+            cell.indexPath = indexPath
             firebaseManager.getUserImage(referencePath: profileImageURL, imageSize: .medium) { downloadedImage in
                 if let image = downloadedImage {
                     DispatchQueue.main.async {

--- a/IDo/View/BasicCell.swift
+++ b/IDo/View/BasicCell.swift
@@ -50,7 +50,7 @@ class BasicCell: UITableViewCell {
         return imageView
     }()
     
-    var storagePath: String?
+    var indexPath: IndexPath?
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -84,10 +84,10 @@ class BasicCell: UITableViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        if let storagePath {
-            FBURLCache.shared.cancelDownloadURL(storagePath: storagePath)
+        if let indexPath {
+            FBURLCache.shared.cancelDownloadURL(indexPath: indexPath)
         }
-        basicImageView.image = nil // 이미지 뷰 초기화
+        basicImageView.image = nil
     }
 }
 


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
모임을 생성할때 이미지가 겹쳐서 나오거나 다른 이미지가 나오는 버그 수정 + 모임 삭제시 내 모임 목록이 전부 안보이는 버그 해결
## 작업내용 (이미지)
