### PR TITLE
[BUG] HomePage 테이블뷰 내 클럽리스트의 이미지가 다른 위치에 들어갔다 돌아오는 버그픽스 + 이미지를 불러오는 중 스크롤시 기존 작업 취소 기능 추가

### DIFF
--- a/IDo/Page/HomePage/HomeViewController.swift
+++ b/IDo/Page/HomePage/HomeViewController.swift
@@ -86,7 +86,6 @@ class HomeViewController : UIViewController {
         guard let uid = Auth.auth().currentUser?.uid else { return }
         MyProfile.shared.getUserProfile(uid: uid) { _ in
             self.updateUIBasedOnData()
-            self.joinClubTableView.reloadData()
         }
         self.navigationController?.setNavigationBackButton(title: "")
     }
@@ -153,10 +152,10 @@ class HomeViewController : UIViewController {
         }
     }
     
-    func getUserClubImage(referencePath: String, imageSize: ImageSize, completion: ((UIImage) -> Void)? = nil) {
+    func getUserClubImage(referencePath: String, imageSize: ImageSize, indexPath: IndexPath, completion: ((UIImage) -> Void)? = nil) {
         // 카테고리 -> meetings_images -> referencePath
         let storageRef = Storage.storage().reference().child(referencePath).child(imageSize.rawValue)
-        FBURLCache.shared.downloadURL(storagePath: storageRef.fullPath) { result in
+        FBURLCache.shared.downloadURL(storagePath: storageRef.fullPath, indexPath: indexPath) { result in
             switch result {
             case .success(let image):
                 completion?(image)
@@ -173,9 +172,9 @@ extension HomeViewController : UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if tableView == suggestTableView {
             return 1
+        } else {
+            return MyProfile.shared.myUserInfo?.myClubList?.count ?? 0
         }
-    
-        return MyProfile.shared.myUserInfo?.myClubList?.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -193,9 +192,10 @@ extension HomeViewController : UITableViewDelegate, UITableViewDataSource {
             cell.titleLabel.text = currentUserClubList[indexPath.row].title
             cell.aboutLabel.text = currentUserClubList[indexPath.row].description
             cell.memberLabel.text = "멤버 \((currentUserClubList[indexPath.row].userList?.count ?? 0))"
-            
+            cell.indexPath = indexPath
+                        
             guard let imageReferencePath = currentUserClubList[indexPath.row].imageURL else { return cell }
-            getUserClubImage(referencePath: imageReferencePath, imageSize: .small) { image in
+            getUserClubImage(referencePath: imageReferencePath, imageSize: .small, indexPath: indexPath) { image in
                 DispatchQueue.main.async {
                     cell.basicImageView.image = image
                 }

--- a/IDo/View/BasicCell.swift
+++ b/IDo/View/BasicCell.swift
@@ -87,7 +87,7 @@ class BasicCell: UITableViewCell {
         if let indexPath {
             FBURLCache.shared.cancelDownloadURL(indexPath: indexPath)
         }
-        basicImageView.image = nil
+        self.basicImageView.image = nil
     }
 }
 


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
사용자 프로필을 불러오고 다시 테이블뷰를 그려서 생기는 문제였음
+ 이미지를 불러오는 중 스크롤시 기존 이미지 불러오는 작업을 취소하는 로직 추가
## 작업내용 (이미지)
![Simulator Screen Recording - iPhone 14 - 2023-12-21 at 20 12 42](https://github.com/FiveI-s/IDo/assets/71269216/46b42d84-91f9-479b-9d27-00064c17c79c)  - 기존 버그가 존재하는 화면
![Simulator Screen Recording - iPhone 14 - 2023-12-21 at 20 11 49](https://github.com/FiveI-s/IDo/assets/71269216/870e6e35-fb46-48ab-831d-7f1d764d5cab)  - 수정후 화면
